### PR TITLE
Fix Date State Persistence Issue

### DIFF
--- a/app/src/pages/proofing/3-fill-in-information/index.tsx
+++ b/app/src/pages/proofing/3-fill-in-information/index.tsx
@@ -15,6 +15,18 @@ import {
 import IDTypeSelectOptions from "src/components/proofing/IDTypeSelectOptions";
 import StateSelectOptions from "src/components/proofing/StateSelectOptions";
 
+function formatDate(inputDate: string): string {
+  if (inputDate === "") {
+    return "";
+  }
+  const originalDate = new Date(inputDate);
+  const formattedDate = Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(originalDate);
+  return formattedDate;
+}
 export default function CaseNumerPage() {
   const contextValue = useContext(ProofingContext);
   const { proofingData, setProofingData } = contextValue || {
@@ -23,20 +35,6 @@ export default function CaseNumerPage() {
       return data;
     },
   };
-
-  function formatDate(inputDate: string): string {
-    const dateArray = inputDate.split("/");
-    const originalDate = new Date(
-      Number(dateArray[2]),
-      Number(dateArray[0]) - 1,
-      Number(dateArray[1])
-    );
-    const year = originalDate.getFullYear();
-    const month = (originalDate.getMonth() + 1).toString().padStart(2, "0");
-    const day = originalDate.getDate().toString().padStart(2, "0");
-    const formattedDate = `${year}-${month}-${day}`;
-    return formattedDate;
-  }
 
   const isContinueButtonDisabled =
     proofingData.socialSecurityNumber === "" ||


### PR DESCRIPTION
## Ticket

Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/70471

## Changes
Fixed Date of Birth Field - Date persists as default value when we hit back from the next page now
<!-- What was added, updated, or removed in this PR. -->

## Context for reviewers
This was not working before because of a string type mismatch 
 defaultValue="2021-01-20" was expected instead the field the dateOfBirth was being stored as is "11/16/2023" 
<!-- Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. -->

## Testing

https://github.com/mo-studio/VA-in-person-identity-proofing/assets/137448668/97b68e19-eca0-4375-b710-cfe910fa58d2


<!-- Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://getkap.co/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox. -->
